### PR TITLE
wip: fix: credhub test failure

### DIFF
--- a/runner/command_line_helpers.go
+++ b/runner/command_line_helpers.go
@@ -21,6 +21,21 @@ func RunCommandSuccessfully(cmd string, args ...string) *gexec.Session {
 	return session
 }
 
+func RunCommandSuccessfullyWithRetries(cmd string, args ...string) *gexec.Session {
+	var session *gexec.Session
+	for i := 0; i < 5; i++ {
+		session = runCommandWithStream("", GinkgoWriter, GinkgoWriter, cmd, args...)
+		if session.ExitCode() == 0 {
+			Expect(session).To(gexec.Exit(0))
+			return session
+		}
+		time.Sleep(10 * time.Second)
+	}
+
+	Expect(session).To(gexec.Exit(0))
+	return session
+}
+
 func RunCommandSuccessfullySilently(cmd string, args ...string) *gexec.Session {
 	session := runCommandWithStream("", bytes.NewBufferString(""), GinkgoWriter, cmd, args...)
 	Expect(session).To(gexec.Exit(0))

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -65,7 +65,6 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + tc.testAppFixturePath + " -b go_buildpack" + " -f " + tc.testAppFixturePath + "/manifest.yml")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
-	fmt.Printf("trying to run cf start with retries\n")
 	RunCommandSuccessfullyWithRetries("cf start " + tc.appName)
 
 	tc.appURL = GetAppURL(tc.appName)

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -24,11 +24,11 @@ type CfCredhubSSITestCase struct {
 func NewCfCredhubSSITestCase() *CfCredhubSSITestCase {
 	id := RandomStringNumber()
 
-  credhubAppPath, appPathPresent := os.LookupEnv("CREDHUB_APP_PATH") 
+	credhubAppPath, appPathPresent := os.LookupEnv("CREDHUB_APP_PATH")
 
-  if no(appPathPresent) {
-    credhubAppPath = path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app")
-  }
+	if no(appPathPresent) {
+		credhubAppPath = path.Join(CurrentTestDir(), "/../fixtures/credhub-test-app")
+	}
 
 	return &CfCredhubSSITestCase{
 		uniqueTestID:       id,
@@ -65,7 +65,8 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + tc.testAppFixturePath + " -b go_buildpack" + " -f " + tc.testAppFixturePath + "/manifest.yml")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
-	RunCommandSuccessfully("cf start " + tc.appName)
+	fmt.Printf("trying to run cf start with retries\n")
+	RunCommandSuccessfullyWithRetries("cf start " + tc.appName)
 
 	tc.appURL = GetAppURL(tc.appName)
 


### PR DESCRIPTION
 - cf start doesn't wait long enough for instances to begin running

Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [ ] What component are you testing? 

### [ ] Is the component an default component in `cf-deployment`?

### [ ] Have you created a `TestCase` and added it to the list of cases to be run?

### [ ] Have you added any new properties/information to all of the following:
* [ ] [integration_config.json](../ci/integration_config.json): Specifically, an `include_<testcase-name>` property
* [ ] [documentation in docs/](../docs/)
* [ ] [tasks in ci/](../ci/)
* [ ] [scripts in scripts/](../scripts/)

### [ ] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?

### [ ] Does this change rely on a particular version of `cf-deployment`?

### [ ] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?

### [ ] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?

### [ ] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?

## Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.