### PR TITLE
Remove bump-ci-tasks job

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -32,9 +32,6 @@ groups:
     - deploy-backup-restore-components
     - run-drats-tests
     - unclaim-cf-deployment-env
-- name: bump
-  jobs:
-    - bump-ci-tasks
 
 resource_types:
 - name: pull-request
@@ -76,19 +73,6 @@ resources:
     base_branch: main
     watch_checks_interval: "30"
     autosync_pr: true
-
-- name: disaster-recovery-acceptance-tests
-  type: git
-  source:
-    uri: git@github.com:cloudfoundry/disaster-recovery-acceptance-tests.git
-    branch: main
-    private_key: *github_ssh_key
-
-- name: disaster-recovery-acceptance-tests-bump-ci-tasks
-  type: git
-  source:
-    uri: git@github.com:cloudfoundry/disaster-recovery-acceptance-tests.git
-    private_key: *github_ssh_key
 
 - name: cf-deployment-env
   icon: pool
@@ -265,47 +249,4 @@ jobs:
     params:
       action: unclaim
       env_file: cf-deployment-env/metadata
-
-- name: bump-ci-tasks
-  plan:
-    - in_parallel:
-      - get: image-cryogenics-essentials
-        trigger: true
-      - get: cryogenics-concourse-tasks
-      - get: disaster-recovery-acceptance-tests
-    - in_parallel:
-      - load_var: cryogenics-essentials-version
-        file: image-cryogenics-essentials/tag
-      - task: bump-tasks
-        image: image-cryogenics-essentials
-        file: cryogenics-concourse-tasks/deps-automation/bump-concourse-tasks/task.yml
-        input_mapping:
-          repo: disaster-recovery-acceptance-tests
-          image: image-cryogenics-essentials
-        output_mapping:
-          repo: disaster-recovery-acceptance-tests
-    - put: disaster-recovery-acceptance-tests-bump-ci-tasks
-      params:
-        repository: disaster-recovery-acceptance-tests
-        branch: &bump-ci-task-branch bump-cryogenics-essentials-to-v((.:cryogenics-essentials-version))
-        force: true
-    - task: create-pull-request
-      image: image-cryogenics-essentials
-      file: cryogenics-concourse-tasks/github-automation/create-pr/task.yml
-      params:
-        BASE: main
-        BRANCH: *bump-ci-task-branch
-        LABELS: dependencies
-        TITLE: Bump cryogenics/essentials to v((.:cryogenics-essentials-version))
-        MESSAGE: |
-          This is an automatically generated Pull Request from the Cryogenics CI Bot.
-
-          I have detected a new version of [cryogenics/essentials](https://hub.docker.com/r/cryogenics/essentials/tags) and automatically bumped
-          this package to benefit from the latest changes.
-
-          If this does not look right, please reach out to the [#mapbu-cryogenics](https://vmware.slack.com/archives/C01DXEYRKRU) team.
-      input_mapping:
-        source-repo: disaster-recovery-acceptance-tests-bump-ci-tasks
-
-
 

--- a/ci/tasks/drats-with-integration-config/task.yml
+++ b/ci/tasks/drats-with-integration-config/task.yml
@@ -3,7 +3,6 @@ image_resource:
   type: registry-image
   source:
     repository: cryogenics/essentials
-    tag: 0.1.70
 inputs:
   - name: disaster-recovery-acceptance-tests
     path: src/github.com/cloudfoundry/disaster-recovery-acceptance-tests

--- a/ci/tasks/drats/task.yml
+++ b/ci/tasks/drats/task.yml
@@ -3,7 +3,6 @@ image_resource:
   type: registry-image
   source:
     repository: cryogenics/essentials
-    tag: 0.1.70
 inputs:
   - name: disaster-recovery-acceptance-tests
     path: src/github.com/cloudfoundry/disaster-recovery-acceptance-tests

--- a/ci/tasks/unit-tests/task.yml
+++ b/ci/tasks/unit-tests/task.yml
@@ -3,7 +3,6 @@ image_resource:
   type: registry-image
   source:
     repository: cryogenics/essentials
-    tag: 0.1.68
 inputs:
   - name: disaster-recovery-acceptance-tests
     path: src/github.com/cloudfoundry/disaster-recovery-acceptance-tests

--- a/ci/tasks/update-integration-config/task.yml
+++ b/ci/tasks/update-integration-config/task.yml
@@ -3,7 +3,6 @@ image_resource:
   type: registry-image
   source:
     repository: cryogenics/essentials
-    tag: 0.1.70
 inputs:
   - name: disaster-recovery-acceptance-tests
   - name: integration-configs


### PR DESCRIPTION
Remove bump-ci-tasks job, this is no longer compatible with Runway an…d OSS community. Tasks will use the latest image

Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [ ] What component are you testing? 

### [ ] Is the component an default component in `cf-deployment`?

### [ ] Have you created a `TestCase` and added it to the list of cases to be run?

### [ ] Have you added any new properties/information to all of the following:
* [ ] [integration_config.json](../ci/integration_config.json): Specifically, an `include_<testcase-name>` property
* [ ] [documentation in docs/](../docs/)
* [ ] [tasks in ci/](../ci/)
* [ ] [scripts in scripts/](../scripts/)

### [ ] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?

### [ ] Does this change rely on a particular version of `cf-deployment`?

### [ ] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?

### [ ] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?

### [ ] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?

## Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.