### PR TITLE
Bugfix/ensure test apps use version from go mod

### DIFF
--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -104,11 +104,10 @@ func (tc *CfCredhubSSITestCase) AfterBackup(config Config) {
 }
 
 func (tc *CfCredhubSSITestCase) GetGoVersionFromGoModFile() string {
-	var file_bytes []byte
-	f, err := modfile.Parse(fmt.Sprintf("%sgo.mod", tc.testAppFixturePath), file_bytes, nil)
-	if err != nil {
-		panic(err)
-	}
+	file_bytes, err := os.ReadFile(fmt.Sprintf("%s/go.mod", tc.testAppFixturePath))
+	Expect(err).NotTo(HaveOccurred())
+	f, err := modfile.Parse(fmt.Sprintf("%s/go.mod", tc.testAppFixturePath), file_bytes, nil)
+	Expect(err).NotTo(HaveOccurred())
 	return f.Go.Version
 
 }

--- a/testcases/credhub_instance_creds_testcase.go
+++ b/testcases/credhub_instance_creds_testcase.go
@@ -63,7 +63,10 @@ func (tc *CfCredhubSSITestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 	RunCommandSuccessfully("cf target -s acceptance-test-space-" + tc.uniqueTestID + " -o acceptance-test-org-" + tc.uniqueTestID)
 
+	goVersion := fmt.Sprintf("go%s", tc.GetGoVersionFromGoModFile())
+
 	RunCommandSuccessfully("cf push " + "--no-start " + tc.appName + " -p " + tc.testAppFixturePath + " -b go_buildpack" + " -f " + tc.testAppFixturePath + "/manifest.yml")
+	RunCommandSuccessfully("cf set-env " + tc.appName + " GOVERSION " + goVersion + " > /dev/null")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_CLIENT " + config.CloudFoundryConfig.CredHubClient + " > /dev/null")
 	RunCommandSuccessfully("cf set-env " + tc.appName + " CREDHUB_SECRET " + config.CloudFoundryConfig.CredHubSecret + " > /dev/null")
 	RunCommandSuccessfully("cf start " + tc.appName)


### PR DESCRIPTION
    fix misunderstanding of docs around modfile.Parse.

    it does in fact not read the filepath provided into file_bytes. It expects file_bytes
    to be populated with the contents of the file.