### PR TITLE
add tagging of repo on merge

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -297,19 +297,20 @@ jobs:
           path: pr
           status: success
           context: drats
-      - put: git-drats-version
-        params:
-          bump: minor
-      - put: git-drats-write
-        params:
-          repository: pr
-          tag: git-drats-version/version
-          only_tag: true
-          tag_prefix: v
       - put: pr
         params:
           path: pr
           merge: true
+      - put: git-drats-version
+        params:
+          bump: minor
+      - get: git-drats
+      - put: git-drats-write
+        params:
+          repository: git-drats
+          tag: git-drats-version/version
+          only_tag: true
+          tag_prefix: v
 
 - name: release-cf-deployment-env
   plan:

--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -113,6 +113,15 @@ resources:
     uri: git@github.com:cloudfoundry/disaster-recovery-acceptance-tests.git
     private_key: *github_ssh_key
 
+- name: git-drats-version
+  type: semver
+  source:
+    uri: git@github.com:cloudfoundry/disaster-recovery-acceptance-tests.git
+    private_key: *github_ssh_key
+    driver: git
+    branch: version
+    file: version
+
 - name: run-once-a-day
   type: time
   icon: timer-outline
@@ -288,6 +297,15 @@ jobs:
           path: pr
           status: success
           context: drats
+      - put: git-drats-version
+        params:
+          bump: minor
+      - put: git-drats-write
+        params:
+          repository: pr
+          tag: git-drats-version/version
+          only_tag: true
+          tag_prefix: v
       - put: pr
         params:
           path: pr


### PR DESCRIPTION
[#186816197]

some repos build on top of these tests and include the code here via the remote repos go.mod file. to have dependabot update those remote go.mod files automatically, this adds tagging of the repo just before the pr is merged once tests passed to avoid dealing with pseudoversions on the remote go.mod files..
