### PR TITLE
improve tagging

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -301,16 +301,20 @@ jobs:
         params:
           path: pr
           merge: true
-      - put: git-drats-version
+      - get: git-drats-version
         params:
-          bump: minor
-      - get: git-drats
+          bump: patch
       - put: git-drats-write
         params:
-          repository: git-drats
+          repository: pr
           tag: git-drats-version/version
           only_tag: true
           tag_prefix: v
+          branch: main
+        ensure:
+          put: git-drats-version
+          params:
+            file: git-drats-version/version
 
 - name: release-cf-deployment-env
   plan:


### PR DESCRIPTION
- switch to patch version bumps
- only bump version when tagging the repo succeeded
- try to tag the repo based on the PR input. the current state of ci will (sometimes?) get HEAD-1 (not including the PR commit) if we get right after merging the PR via put: pr..

