### PR TITLE
Ci/improve tagging

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -297,20 +297,16 @@ jobs:
           path: pr
           status: success
           context: drats
-      - put: pr
-        params:
-          path: pr
-          merge: true
       - get: git-drats-version
         params:
           bump: patch
-      - put: git-drats-write
+      - put: git-drats #this is intentionally not putting on git-drats-write because this wants to write to main and the generated version is expected.
         params:
           repository: pr
           tag: git-drats-version/version
-          only_tag: true
           tag_prefix: v
           branch: main
+          merge: true
         ensure:
           put: git-drats-version
           params:


### PR DESCRIPTION
CI currently fails and this attempts to fix it. 

replace how the merge is done

using the pr resource to merge makes things complicated in this context
    - if after put: pr a get step is attempted, the in result will be the state of
      the repo prior to the merge. I assume this is a race condition and would require
      a sleep to solve.
    - if the put is done via the git resource, using the available `pr` resource version,
      the the implied get step after the put will fail

    switch the merge to be done via a put of the git resource after loading the branch name