### PR TITLE
all bumpers should be serial

### DIFF
--- a/ci/pipelines/drats/pipeline.yml
+++ b/ci/pipelines/drats/pipeline.yml
@@ -337,6 +337,7 @@ jobs:
       resource: cf-deployment-env
 
 - name: bump-go-module
+  serial: true
   plan:
   - in_parallel:
     - get: source-repo


### PR DESCRIPTION
[#187071309]
they currently force push. That created issues when the same job got triggered twice ( for unknown reasons ) and job n-1 "overtook" job n ( n used a newer HEAD ) and force pushed over the changes made by n.

Thanks for submitting a PR to DRATs.
