### PR TITLE
httpd is part of core images

### DIFF
--- a/testcases/nfs_testcase.go
+++ b/testcases/nfs_testcase.go
@@ -48,7 +48,7 @@ func (tc *NFSTestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space " + spaceName + " -o " + orgName)
 	RunCommandSuccessfully("cf target -o " + orgName + " -s " + spaceName)
 	RunCommandSuccessfully("cf enable-feature-flag diego_docker")
-	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+	RunCommandSuccessfully("cf push dratsApp --docker-image httpd --no-start --random-route")
 
 	if config.CloudFoundryConfig.NFSCreateServiceBroker {
 		RunCommandSuccessfully("cf create-service-broker nfsbroker-drats-" + tc.uniqueTestID + " " +
@@ -69,7 +69,7 @@ func (tc *NFSTestCase) AfterBackup(config Config) {
 
 func (tc *NFSTestCase) EnsureAfterSelectiveRestore(config Config) {
 	By("repushing apps if restoring from a selective restore")
-	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+	RunCommandSuccessfully("cf push dratsApp --docker-image httpd --no-start --random-route")
 }
 
 func (tc *NFSTestCase) AfterRestore(config Config) {

--- a/testcases/smb_testcase.go
+++ b/testcases/smb_testcase.go
@@ -48,7 +48,7 @@ func (tc *SMBTestCase) BeforeBackup(config Config) {
 	RunCommandSuccessfully("cf create-space " + spaceName + " -o " + orgName)
 	RunCommandSuccessfully("cf target -o " + orgName + " -s " + spaceName)
 	RunCommandSuccessfully("cf enable-feature-flag diego_docker")
-	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+	RunCommandSuccessfully("cf push dratsApp --docker-image httpd --no-start --random-route")
 
 	if config.CloudFoundryConfig.SMBCreateServiceBroker {
 		RunCommandSuccessfully("cf create-service-broker " + "smbbroker-drats-" + tc.uniqueTestID + " " +
@@ -68,7 +68,7 @@ func (tc *SMBTestCase) AfterBackup(config Config) {
 }
 func (tc *SMBTestCase) EnsureAfterSelectiveRestore(config Config) {
 	By("repushing apps if restoring from a selective restore")
-	RunCommandSuccessfully("cf push dratsApp --docker-image docker/httpd --no-start --random-route")
+	RunCommandSuccessfully("cf push dratsApp --docker-image httpd --no-start --random-route")
 }
 
 func (tc *SMBTestCase) AfterRestore(config Config) {


### PR DESCRIPTION
docker prefix doesn't work when we start the image. This PR will remove the prefix so that images can be started

Thanks for submitting a PR to DRATs.

## Checklist

Please provide the following information (and links if possible):

### [ ] What component are you testing? 

### [ ] Is the component an default component in `cf-deployment`?

### [ ] Have you created a `TestCase` and added it to the list of cases to be run?

### [ ] Have you added any new properties/information to all of the following:
* [ ] [integration_config.json](../ci/integration_config.json): Specifically, an `include_<testcase-name>` property
* [ ] [documentation in docs/](../docs/)
* [ ] [tasks in ci/](../ci/)
* [ ] [scripts in scripts/](../scripts/)

### [ ] Have you manually validated your `TestCase` against a deployed Cloud Foundry? If so, which version?

### [ ] Does this change rely on a particular version of `cf-deployment`?

### [ ] Are there any optional components of Cloud Foundry that should be enabled for this new `TestCase` to succeed?  Are their presence checked for in the `CheckDeployment` method of your `TestCase`?

### [ ] Are you available for a cross-team pair to help troubleshoot your PR?  What timezones are you based in?

### [ ] Have you submitted a pull-request to modify the `cf-deployment` [backup and restore ops files](https://github.com/cloudfoundry/cf-deployment/blob/master/operations/backup-and-restore/) to add a backup job and properties where appropriate?

## Do you have any other useful information for us?

We're on the #bbr cloudfoundry Slack channel if you need us.